### PR TITLE
Handle TreatWarningsAsErrors a bit better

### DIFF
--- a/src/com/google/javascript/jscomp/PlovrCompilerOptions.java
+++ b/src/com/google/javascript/jscomp/PlovrCompilerOptions.java
@@ -38,4 +38,19 @@ public class PlovrCompilerOptions extends CompilerOptions {
   public Charset getOutputCharset() {
     return super.getOutputCharset();
   }
+
+  private boolean treatWarningsAsErrors = false;
+
+  /**
+   * If treatWarningsAsErrors is set to true, future calls to setWarningLevel
+   * will always interpret WARNING as ERROR.
+   */
+  public void setTreatWarningsAsErrors(boolean value) {
+    treatWarningsAsErrors = value;
+  }
+
+  @Override public void setWarningLevel(DiagnosticGroup group, CheckLevel level) {
+    boolean escalateToError = treatWarningsAsErrors && level == CheckLevel.WARNING;
+    super.setWarningLevel(group, escalateToError ? CheckLevel.ERROR : level);
+  }
 }

--- a/src/org/plovr/Config.java
+++ b/src/org/plovr/Config.java
@@ -503,6 +503,9 @@ public final class Config implements Comparable<Config> {
     CompilationLevel level = compilationMode.getCompilationLevel();
     logger.info("Compiling with level: " + level);
     PlovrCompilerOptions options = new PlovrCompilerOptions();
+
+    options.setTreatWarningsAsErrors(getTreatWarningsAsErrors());
+
     level.setOptionsForCompilationLevel(options);
     if (debug) {
       level.setDebugOptionsForCompilationLevel(options);


### PR DESCRIPTION
This fixes a bug I introduced where some warnings were still getting reported as warnings, even when treatWarningsAsErrors was on.
