### PR TITLE
Support excluding of warnings via regex pattern

### DIFF
--- a/src/org/plovr/Compilation.java
+++ b/src/org/plovr/Compilation.java
@@ -89,7 +89,7 @@ public final class Compilation {
     if (config.getCompilationMode() == CompilationMode.RAW) {
       compileRaw(config);
     } else {
-      PlovrClosureCompiler compiler = new PlovrClosureCompiler(config.getErrorStream());
+      PlovrClosureCompiler compiler = new PlovrClosureCompiler(new PlovrErrorManager(config));
       compile(config, compiler, config.getCompilerOptions(compiler));
     }
   }

--- a/src/org/plovr/Config.java
+++ b/src/org/plovr/Config.java
@@ -166,6 +166,8 @@ public final class Config implements Comparable<Config> {
 
   private final PrintStream errorStream;
 
+  private final Set<Pattern> warningExcludePaths;
+
   /**
    * @param id Unique identifier for the configuration. This is used as an
    *        argument to the &lt;script> tag that loads the compiled code.
@@ -215,7 +217,8 @@ public final class Config implements Comparable<Config> {
       List<String> allowedNonStandardCssFunctions,
       String gssFunctionMapProviderClassName,
       File cssOutputFile,
-      PrintStream errorStream) {
+      PrintStream errorStream,
+      Set<Pattern> warningExcludePaths) {
     Preconditions.checkNotNull(defines);
 
     this.id = id;
@@ -263,6 +266,7 @@ public final class Config implements Comparable<Config> {
     this.gssFunctionMapProviderClassName = gssFunctionMapProviderClassName;
     this.cssOutputFile = cssOutputFile;
     this.errorStream = Preconditions.checkNotNull(errorStream);
+    this.warningExcludePaths = warningExcludePaths;
   }
 
   public static Builder builder(File relativePathBase, File configFile,
@@ -344,7 +348,7 @@ public final class Config implements Comparable<Config> {
    * in response to an HTTP request.
    */
   public String getJsContentType() {
-    return "text/javascript; charset=" + outputCharset.name();
+    return "application/javascript; charset=" + outputCharset.name();
   }
 
   /**
@@ -470,6 +474,8 @@ public final class Config implements Comparable<Config> {
   public PrintStream getErrorStream() {
     return errorStream;
   }
+
+  public Set<Pattern> getWarningExcludePaths() { return warningExcludePaths; }
 
   public List<WebDriverFactory> getWebDriverFactories() {
     return ImmutableList.copyOf(testDrivers);
@@ -933,6 +939,8 @@ public final class Config implements Comparable<Config> {
 
     private PrintStream errorStream = System.err;
 
+    private Set<Pattern> warningExcludePaths = Sets.newHashSet();
+
     /**
      * Pattern to validate a config id. A config id may not contain funny
      * characters, such as slashes, because ids are used in RESTful URLs, so
@@ -1012,6 +1020,7 @@ public final class Config implements Comparable<Config> {
           gssFunctionMapProviderClassName;
       this.cssOutputFile = config.cssOutputFile;
       this.errorStream = config.errorStream;
+      this.warningExcludePaths = config.warningExcludePaths;
     }
 
     /** Directory against which relative paths should be resolved. */
@@ -1377,6 +1386,14 @@ public final class Config implements Comparable<Config> {
       this.errorStream = Preconditions.checkNotNull(errorStream);
     }
 
+    public void addWarningExcludePath(Pattern path) {
+      warningExcludePaths.add(path);
+    }
+
+    public void resetWarningExcludePaths() {
+      warningExcludePaths.clear();
+    }
+
     public Config build() {
       File closureLibraryDirectory = pathToClosureLibrary != null
           ? new File(pathToClosureLibrary)
@@ -1462,7 +1479,8 @@ public final class Config implements Comparable<Config> {
           allowedNonStandardFunctions,
           gssFunctionMapProviderClassName,
           cssOutputFile,
-          errorStream);
+          errorStream,
+          warningExcludePaths);
 
       return config;
     }

--- a/src/org/plovr/ConfigOption.java
+++ b/src/org/plovr/ConfigOption.java
@@ -775,21 +775,21 @@ public enum ConfigOption {
 
     @Override
     public void apply(String pattern, Config.Builder builder) {
-        Pattern path = Pattern.compile(pattern);
-        builder.addWarningExcludePath(path);
+      Pattern path = Pattern.compile(pattern);
+      builder.addWarningExcludePath(path);
     }
 
     @Override
     public void apply(JsonArray warningExcludePaths, Config.Builder builder) {
-        for (JsonElement item : warningExcludePaths) {
-            apply(item.getAsString(), builder);
-        }
+      for (JsonElement item : warningExcludePaths) {
+        apply(item.getAsString(), builder);
+      }
     }
 
     @Override
     public boolean reset(Config.Builder builder) {
-        builder.resetWarningExcludePaths();
-        return true;
+      builder.resetWarningExcludePaths();
+      return true;
     }
   });
 

--- a/src/org/plovr/ConfigOption.java
+++ b/src/org/plovr/ConfigOption.java
@@ -3,6 +3,7 @@ package org.plovr;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.plovr.ModuleConfig.BadDependencyTreeException;
 import org.plovr.webdriver.ReflectionWebDriverFactory;
@@ -769,7 +770,28 @@ public enum ConfigOption {
       builder.setCssOutputFile(outputFile);
     }
   }),
-  ;
+
+  WARNING_EXCLUDE_PATHS("warning-exclude-paths", new ConfigUpdater() {
+
+    @Override
+    public void apply(String pattern, Config.Builder builder) {
+        Pattern path = Pattern.compile(pattern);
+        builder.addWarningExcludePath(path);
+    }
+
+    @Override
+    public void apply(JsonArray warningExcludePaths, Config.Builder builder) {
+        for (JsonElement item : warningExcludePaths) {
+            apply(item.getAsString(), builder);
+        }
+    }
+
+    @Override
+    public boolean reset(Config.Builder builder) {
+        builder.resetWarningExcludePaths();
+        return true;
+    }
+  });
 
   private static class ConfigUpdater {
 

--- a/src/org/plovr/PlovrClosureCompiler.java
+++ b/src/org/plovr/PlovrClosureCompiler.java
@@ -2,6 +2,8 @@ package org.plovr;
 
 import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.DiagnosticGroups;
+import com.google.javascript.jscomp.ErrorManager;
+
 import java.io.PrintStream;
 
 /**
@@ -17,6 +19,8 @@ public class PlovrClosureCompiler extends Compiler {
   private PlovrDiagnosticGroups diagnosticGroups = new PlovrDiagnosticGroups();
 
   public PlovrClosureCompiler(PrintStream errorStream) { super(errorStream); }
+
+  public PlovrClosureCompiler(ErrorManager errorManager) { super(errorManager); }
 
   @Override
   protected PlovrDiagnosticGroups getDiagnosticGroups() {

--- a/src/org/plovr/PlovrErrorManager.java
+++ b/src/org/plovr/PlovrErrorManager.java
@@ -1,0 +1,58 @@
+package org.plovr;
+
+import com.google.common.collect.Maps;
+import com.google.javascript.jscomp.CheckLevel;
+import com.google.javascript.jscomp.JSError;
+import com.google.javascript.jscomp.PrintStreamErrorManager;
+
+import java.io.PrintStream;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ */
+public class PlovrErrorManager extends PrintStreamErrorManager {
+    private final Set<Pattern> warningExcludePaths;
+    private Config config;
+    private Map<Pattern,Integer> excludeCounts = Maps.newHashMap();
+    private int excludedWarningCount = 0;
+
+    public PlovrErrorManager(Config config) {
+        super(config.getErrorStream());
+        this.config = config;
+        this.warningExcludePaths = config.getWarningExcludePaths();
+    }
+
+    @Override
+    public void println(CheckLevel level, JSError error) {
+        String sourceName = error.sourceName;
+        boolean exclude = false;
+        for(Pattern warningExcludePath: this.warningExcludePaths) {
+            if(warningExcludePath.matcher(sourceName).matches()) {
+                exclude = true;
+                excludedWarningCount++;
+                break;
+            }
+        }
+        if(!exclude) {
+            super.println(level, error);
+        }
+    }
+
+    public int getExcludedWarningCount() {
+        return excludedWarningCount;
+    }
+
+    @Override
+    public int getWarningCount() {
+        return super.getWarningCount() - this.getExcludedWarningCount();
+    }
+
+    @Override
+    public void printSummary() {
+        PrintStream stream = config.getErrorStream();
+        stream.format("%d error(s), %d warning(s), %d excluded warning(s), %.1f%% typed%n",
+            getErrorCount(), getWarningCount(), getExcludedWarningCount(), getTypedPercent());
+    }
+}

--- a/src/org/plovr/PlovrErrorManager.java
+++ b/src/org/plovr/PlovrErrorManager.java
@@ -10,49 +10,48 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-/**
- */
+
 public class PlovrErrorManager extends PrintStreamErrorManager {
-    private final Set<Pattern> warningExcludePaths;
-    private Config config;
-    private Map<Pattern,Integer> excludeCounts = Maps.newHashMap();
-    private int excludedWarningCount = 0;
+  private final Set<Pattern> warningExcludePaths;
+  private Config config;
+  private Map<Pattern,Integer> excludeCounts = Maps.newHashMap();
+  private int excludedWarningCount = 0;
 
-    public PlovrErrorManager(Config config) {
-        super(config.getErrorStream());
-        this.config = config;
-        this.warningExcludePaths = config.getWarningExcludePaths();
-    }
+  public PlovrErrorManager(Config config) {
+    super(config.getErrorStream());
+    this.config = config;
+    this.warningExcludePaths = config.getWarningExcludePaths();
+  }
 
-    @Override
-    public void println(CheckLevel level, JSError error) {
-        String sourceName = error.sourceName;
-        boolean exclude = false;
-        for(Pattern warningExcludePath: this.warningExcludePaths) {
-            if(warningExcludePath.matcher(sourceName).matches()) {
-                exclude = true;
-                excludedWarningCount++;
-                break;
-            }
-        }
-        if(!exclude) {
-            super.println(level, error);
-        }
+  @Override
+  public void println(CheckLevel level, JSError error) {
+    String sourceName = error.sourceName;
+    boolean exclude = false;
+    for(Pattern warningExcludePath: this.warningExcludePaths) {
+      if(warningExcludePath.matcher(sourceName).matches()) {
+        exclude = true;
+        excludedWarningCount++;
+        break;
+      }
     }
+    if(!exclude) {
+      super.println(level, error);
+    }
+  }
 
-    public int getExcludedWarningCount() {
-        return excludedWarningCount;
-    }
+  public int getExcludedWarningCount() {
+    return excludedWarningCount;
+  }
 
-    @Override
-    public int getWarningCount() {
-        return super.getWarningCount() - this.getExcludedWarningCount();
-    }
+  @Override
+  public int getWarningCount() {
+    return super.getWarningCount() - this.getExcludedWarningCount();
+  }
 
-    @Override
-    public void printSummary() {
-        PrintStream stream = config.getErrorStream();
-        stream.format("%d error(s), %d warning(s), %d excluded warning(s), %.1f%% typed%n",
-            getErrorCount(), getWarningCount(), getExcludedWarningCount(), getTypedPercent());
-    }
+  @Override
+  public void printSummary() {
+    PrintStream stream = config.getErrorStream();
+    stream.format("%d error(s), %d warning(s), %d excluded warning(s), %.1f%% typed%n",
+        getErrorCount(), getWarningCount(), getExcludedWarningCount(), getTypedPercent());
+  }
 }

--- a/src/org/plovr/PlovrErrorManager.java
+++ b/src/org/plovr/PlovrErrorManager.java
@@ -27,14 +27,14 @@ public class PlovrErrorManager extends PrintStreamErrorManager {
   public void println(CheckLevel level, JSError error) {
     String sourceName = error.sourceName;
     boolean exclude = false;
-    for(Pattern warningExcludePath: this.warningExcludePaths) {
-      if(warningExcludePath.matcher(sourceName).matches()) {
+    for (Pattern warningExcludePath : this.warningExcludePaths) {
+      if (warningExcludePath.matcher(sourceName).matches()) {
         exclude = true;
         excludedWarningCount++;
         break;
       }
     }
-    if(!exclude) {
+    if (!exclude) {
       super.println(level, error);
     }
   }


### PR DESCRIPTION
Dear @bolinfest, I am hoping that you may consider this pull request.

I believe this will allow a close  to [Issue 1: Make it possible to suppress warnings from individual JS file](https://code.google.com/p/plovr/issues/detail?id=1).

Example usage
```c
  # plovr.cfg
  {
    "warning-exclude-paths": [
    "^/closure/goog/testing/stacktrace.js",
    "^/closure/goog/iter/iter.js",
    "^/closure/goog/labs/promise/promise.js",
    "^/closure/goog/labs/promise/thenable.js",
    # transitive dependencies seem to resolved more fully...
    ".*?/closure/goog/mochikit/async/deferred.js"
    ],
  }
```
In the interests of other warning suppression, this branch also updates the Config.getJsContentType method to return `application/javascript` instead of `text/javascript` since the latter seems to upset HtmlUnit:

```syslog
WARNING: Obsolete content type encountered: 'text/javascript'
```

Many thanks for considering this pull request, and for plovr itself.

Sincerely,
Rick Power