### PR TITLE
add --base-url option to serve command, thus making it possible to place plovr behind a reverse proxy

### DIFF
--- a/src/org/plovr/CompilationServer.java
+++ b/src/org/plovr/CompilationServer.java
@@ -25,6 +25,8 @@ public final class CompilationServer implements Runnable {
 
   private final boolean isHttps;
 
+  private final String baseUrl;
+
   // All maps are keyed on a Config id rather than a Config because there could
   // be multiple, different Config objects with the same id because of how query
   // data can be used to redefine a Config for an individual request.
@@ -39,10 +41,12 @@ public final class CompilationServer implements Runnable {
    */
   private final ConcurrentMap<String, Compilation> compilations;
 
-  public CompilationServer(String listenAddress, int port, boolean isHttps) {
+  public CompilationServer(String listenAddress, int port, boolean isHttps,
+                           String baseUrl) {
     this.listenAddress = listenAddress;
     this.port = port;
     this.isHttps = isHttps;
+    this.baseUrl = baseUrl;
     this.configs = Maps.newConcurrentMap();
     this.compilations = Maps.newConcurrentMap();
   }
@@ -173,6 +177,9 @@ public final class CompilationServer implements Runnable {
    * @return the server scheme, name, and port, such as "http://localhost:9810/"
    */
   public String getServerForExchange(HttpExchange exchange) {
+    if (this.baseUrl != null) {
+        return this.baseUrl;
+    }
     URI referrer = HttpUtil.getReferrer(exchange);
     String scheme;
     String host;

--- a/src/org/plovr/cli/ServeCommand.java
+++ b/src/org/plovr/cli/ServeCommand.java
@@ -25,7 +25,8 @@ public class ServeCommand extends AbstractCommandRunner<ServeCommandOptions> {
 
     CompilationServer server = new CompilationServer(options.getListenAddress(),
         options.getPort(),
-        options.isHttps());
+        options.isHttps(),
+        options.getBaseUrl());
     // Register all of the configs.
     for (String arg : arguments) {
       File configFile = new File(arg);

--- a/src/org/plovr/cli/ServeCommandOptions.java
+++ b/src/org/plovr/cli/ServeCommandOptions.java
@@ -24,6 +24,10 @@ public class ServeCommandOptions extends AbstractCommandOptions {
       usage = "Serve via https://")
   private boolean isHttps = false;
 
+  @Option(name = "--base-url",
+      usage = "Use this URL as the base for server-generated URLs.")
+  private String baseUrl = null;
+
   @Argument
   private List<String> arguments = Lists.newLinkedList();
 
@@ -37,6 +41,10 @@ public class ServeCommandOptions extends AbstractCommandOptions {
 
   public boolean isHttps() {
     return isHttps;
+  }
+
+  public String getBaseUrl() {
+    return baseUrl;
   }
 
   public List<String> getArguments() {


### PR DESCRIPTION
This updates CompilationServer's getServerForExchange() so that it can
return a fixed base URL instead of re-constructing it from the referrer
header in the request. In so doing, we make it possible to serve plovr
from behind a reverse proxy. For instance, if your development server's
nginx is configured with:

```
location /static/debug/plovr/ {
    proxy_pass http://localhost:9810/;
}
```

you may now configure plovr such that the URLs it generates are prefixed
with http://localhost/static/debug/plovr/ by running:

```
java -jar plovr.jar serve \
    --base-url https://local.dev.foo.com/static/debug/plovr/ \
    plovr_config.json
```
