### PR TITLE
Fix listfiles.sh script producing an extra line when CDPATH is set.

### DIFF
--- a/listfiles.sh
+++ b/listfiles.sh
@@ -2,7 +2,7 @@
 # trying to accomplish the equivalent thing in pure Ant.
 
 # Change to the directory to eliminate any relative directory prefix.
-cd $1
+cd $1 > /dev/null
 
 # Remove the "./" from the beginning of each entry, and exclude deps.js files.
 find . -name '*.js' | grep -v deps.js | cut -b 3-


### PR DESCRIPTION
The shell causes `cd $1` to print the current directory when CDPATH is
set. Th extra printed line causes the produced output jar to be broken.
