### PR TITLE
Add stop() to CompilationServer and Server

### DIFF
--- a/src/org/plovr/soy/server/Server.java
+++ b/src/org/plovr/soy/server/Server.java
@@ -16,14 +16,19 @@ public final class Server implements Runnable {
 
   private final Config config;
 
+  private HttpServer server;
+
   public Server(Config config) {
     this.config = config;
   }
 
   @Override
   public void run() {
+    if (server != null) {
+      throw new RuntimeException("Server already started");
+    }
+
     InetSocketAddress addr = new InetSocketAddress(config.getPort());
-    HttpServer server;
     try {
       // 0 indicates the system default should be used.
       final int maxQueuedIncomingConnections = 0;
@@ -38,4 +43,24 @@ public final class Server implements Runnable {
     server.createContext("/", new RequestHandlerSelector(config));
     server.start();
   }
+
+  /**
+   * Synonym for {@link #run()}
+   */
+  public void start() {
+    run();
+  }
+
+  /**
+   * Stop listening and close all connections.
+   * @param delay Seconds to wait for existing connections to finish.
+   */
+  public void stop(int delay) {
+    if (server == null) {
+      throw new RuntimeException("Server not started");
+    }
+    server.stop(delay);
+    server = null;
+  }
+
 }


### PR DESCRIPTION
I'm using Plovr via Java rather than the CLI.

This adds `stop()` to `CompilationServer` and `Server`, so I can stop the server.

For consistency, I renamed `run()` to `start()` (and removed the `Runnable` interface).
Typically, `run()` implies that it runs synchronously, i.e. does not exist until it is finished, where `start()` implies it runs asynchronously relative to the current thread. 

Though the naming really doesn't matter to me one way or the other, just the addition of `stop()`.