### PR TITLE
Update website links to point to the GitHub repo.

### DIFF
--- a/www/demo/index.soy
+++ b/www/demo/index.soy
@@ -30,15 +30,15 @@
 <h1>plovr demo page</h1>
 
 This is a demo for{sp}
-<a href="http://code.google.com/p/plovr/">plovr</a>, a{sp}
-<a href="http://code.google.com/closure/">Closure</a> build tool.
+<a href="https://github.com/bolinfest/plovr">plovr</a>, a{sp}
+<a href="https://developers.google.com/closure/">Closure</a> build tool.
 
 <h2>About plovr</h2>
 
 <p>
 plovr is a bulid tool that dynamically recompiles JavaScript and
 Closure Template code. Once you create a <a
-href="http://code.google.com/p/plovr/source/browse/testdata/example/integration-test-config.js">simple
+href="https://github.com/bolinfest/plovr/blob/master/testdata/example/integration-test-config.js">simple
 configuration file</a> to tell plovr where the JS and Soy files to
 compile are on your local machine, simply run the plovr jar with the
 config file to start compiling your code. The output of
@@ -46,10 +46,10 @@ plovr can be included via a <code>&lt;script></code> tag.
 </p>
 
 <p>
-Visit the <a href="http://code.google.com/p/plovr/downloads/list">downloads
-page on code.google.com</a> to get the latest plovr binary, or <a
-href="http://code.google.com/p/plovr/source/checkout">check out the
-source</a> and build it yourself.
+Visit the <a href="https://github.com/bolinfest/plovr/releases">releases
+page on GitHub</a> to get the latest plovr binary, or <a
+href="https://github.com/bolinfest/plovr">check out the source</a> and build it
+yourself.
 </p>
 
 <h2>Live Examples</h2>
@@ -68,7 +68,7 @@ The <a href="demo-config.js">config file</a> tells plovr to
 compile <a href="example/main.js">example/main.js</a> and to look in{sp}
 <a href="example/">example</a> when searching for its JavaScript and Soy dependencies.
 By default, any JavaScript file in the Closure Library (as well as{sp}
-<a href="http://code.google.com/p/closure-templates/source/browse/trunk/javascript/soyutils_usegoog.js">soyutils_usegoog.js</a>)
+<a href="https://github.com/google/closure-templates/blob/master/javascript/soyutils_usegoog.js">soyutils_usegoog.js</a>)
 may also be transitively included as a dependency.
 
 </p>
@@ -103,7 +103,7 @@ and plovr will recompile the inputs!
     In <code>WHITESPACE</code> mode, after being topologically sorted,
     all input files are concatenated together into a single JavaScript
     file with all whitespace and comments removed using the{sp}
-    <a href="http://code.google.com/closure/compiler/docs/compilation_levels.html">
+    <a href="https://developers.google.com/closure/compiler/docs/compilation_levels">
     WHITESPACE_ONLY</a> mode of the Closure Compiler.
   </li>
   <li>

--- a/www/docs.soy
+++ b/www/docs.soy
@@ -50,7 +50,7 @@ today.) The following is an example of a minimal (but functional) plovr config f
 
 An example of a more complex config file (that leverages the modules
 feature of the Compiler){sp}
-<a href="http://code.google.com/p/plovr/source/browse/testdata/modules/plovr-config.js">
+<a href="https://github.com/bolinfest/plovr/blob/master/testdata/modules/plovr-config.js">
 can be seen in the plovr repository</a>.
 A config file declares which files should be compiled,
 where its dependencies can be found, and which compilation options should be
@@ -113,7 +113,7 @@ that will facilitate this process.)
 <h2>More on Config Files</h2>
 
 Config options are enumerated in the Java source code in{sp}
-<a href="http://code.google.com/p/plovr/source/browse/src/org/plovr/ConfigOption.java">ConfigOption.java</a>.
+<a href="https://github.com/bolinfest/plovr/blob/master/src/org/plovr/ConfigOption.java">ConfigOption.java</a>.
 As plovr is evaluated by Closure developers, the names and JSON data types for
 these options may change, so until the API is frozen, the source code is the
 source of truth for what is expected.
@@ -152,9 +152,9 @@ follows:
 
 It is also possible to set the level for various types of Compiler checks with the{sp}
 <code>checks</code> property. Many of these checks are explained on the{sp}
-<a href="http://code.google.com/p/closure-compiler/wiki/Warnings">Closure
+<a href="https://github.com/google/closure-compiler/wiki/Warnings">Closure
 Compiler wiki</a>, though the <code>DIAGNOSTIC_GROUP_NAMES</code> variable in{sp}
-<a href="http://code.google.com/p/closure-compiler/source/browse/trunk/src/com/google/javascript/jscomp/DiagnosticGroups.java">DiagnosticGroups.java</a>
+<a href="https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/DiagnosticGroups.java">DiagnosticGroups.java</a>
 {sp}is the real source of truth:
 
 {literal}
@@ -165,7 +165,7 @@ Compiler wiki</a>, though the <code>DIAGNOSTIC_GROUP_NAMES</code> variable in{sp
   "mode": "ADVANCED",
   "level": "VERBOSE",
   "checks": {
-    <span style="color: #A00">// acceptable values are "ERROR", "WARNING", and "OFF"</span> 
+    <span style="color: #A00">// acceptable values are "ERROR", "WARNING", and "OFF"</span>
     "deprecated": "ERROR",
     "checkTypes": "ERROR",
     "nonStandardJsDocs": "WARNING"
@@ -181,12 +181,12 @@ but such comments <em>are</em> allowed in plovr config files.)
 
 Remember, the names and values of the config file have not been finalized, so
 it may be necessary to monitor the plovr source code as new versions are
-released.   
+released.
 
 <h2>Using plovr With Compiler Modules</h2>
 
 Currently, the best way to learn how to use the modules feature of plovr is to
-examine the <a href="http://code.google.com/p/plovr/source/browse/#hg/testdata/modules">
+examine the <a href="https://github.com/bolinfest/plovr/tree/master/testdata/modules">
 modules example in the plovr codebase</a>.
 It is based off of the example in the "Partitioning Compiled Code into Modules"
 section in Chapter 12 of <span class="book-title">Closure: The Definitive Guide</span>.
@@ -212,7 +212,7 @@ there are other URLs that plovr serves to provide additional information.
 Some of these are listed on the{sp}
 <a href="http://code.google.com/p/plovr/wiki/GettingStarted">plovr wiki page
 on Google Code</a>, though the best way to get the complete list is by{sp}
-<a href="http://code.google.com/p/plovr/source/browse/src/org/plovr/Handler.java">
+<a href="https://github.com/bolinfest/plovr/blob/master/src/org/plovr/Handler.java">
 exploring the plovr source code</a>.
 There is also more information on these features of plovr in Appendix C
 of <span class="book-title">Closure: The Definitive Guide</span>.

--- a/www/download.soy
+++ b/www/download.soy
@@ -9,8 +9,8 @@
 {/call}
 
 <p>
-You can <a href="http://code.google.com/p/plovr/downloads/list">download a
-pre-built binary of plovr from Google Code</a>.
+You can <a href="https://github.com/bolinfest/plovr/releases">download a
+pre-built binary of plovr from GitHub</a>.
 As you will see, binaries that are available for download are named with
 revision numbers from version control rather than with formal version numbers.
 This is because plovr is still in the alpha stage, as it merits more feedback
@@ -21,14 +21,14 @@ feedback and names have stabilized, an official beta will be released.
 
 <p>
 plovr is open-sourced under the Apache 2.0 license.
-Its <a href="http://code.google.com/p/plovr/source/checkout">
-source code is available on Google Code</a> via a Mercurial repository.
+Its <a href="https://github.com/bolinfest/plovr">
+source code is available on GitHub</a>.
 The plovr repository includes branches which are copies of the Closure Library,
 Closure Compiler, and Closure Templates source code, so building plovr is
 entirely self-contained:
 </p>
 
-{literal}<pre>hg clone https://plovr.googlecode.com/hg/ plovr
+{literal}<pre>git clone git@github.com:bolinfest/plovr.git
 cd plovr
 ant jar</pre>{/literal}
 

--- a/www/index.soy
+++ b/www/index.soy
@@ -18,7 +18,7 @@
 
 plovr is a build tool that dynamically recompiles JavaScript and Closure
 Template code. It is designed to
-simplify <a href="http://code.google.com/closure/">Closure</a> development,
+simplify <a href="https://developers.google.com/closure/">Closure</a> development,
 and to make it more enjoyable.
 
 <p>The intended usage of plovr is as follows:</p>

--- a/www/soyweb.soy
+++ b/www/soyweb.soy
@@ -304,7 +304,7 @@ behavior:
 <li><code class="option">--globals</code> refers to a JSON file containing a map
     of global variable names to values. If supplied, SoyWeb will supply these
     values as globals when rendering a template. See{sp}
-    <a href="http://code.google.com/p/plovr/source/browse/www-globals.js"
+    <a href="https://github.com/bolinfest/plovr/blob/master/www-globals.js"
        target="_blank">www-globals.js</a> for an example of this.
 <li><code class="option">--static</code> if specified, disables SoyWeb's default
     serving behavior, which is to reload a template each time it is requested.

--- a/www/testing.soy
+++ b/www/testing.soy
@@ -22,7 +22,7 @@ from one page.
 
 This page is intended to provide the minimum amount of information that you need
 to get started with the Closure Test Framework. For more information, please see
-{sp}{call plovr.simpleBookLink /}. 
+{sp}{call plovr.simpleBookLink /}.
 
 <h3>Writing a Test</h3>
 
@@ -57,7 +57,7 @@ JavaScript separate from the HTML will make this easier to implement.
 Start plovr in server mode and navigate
 to <b>http://localhost:9810/</b> as you normally would to see the list
 of configs that plovr is serving. Under each config, you should see a link to
-{sp}<b>list of tests</b>. Follow that link and you will see the list of the 
+{sp}<b>list of tests</b>. Follow that link and you will see the list of the
 HTML files that plovr has created so you can run your tests.
 There should be one page for each of your test cases.
 
@@ -84,8 +84,8 @@ another so that you can easily switch between running one or all of your tests.
 
 plovr generates the HTML for your test case from a Soy template. The default
 template that plovr uses can be found in{sp}
-<a href="http://code.google.com/p/plovr/source/browse/src/org/plovr/test.soy">test.soy</a>
-{sp}and is named <code>org.plovr.test</code>. 
+<a href="https://github.com/bolinfest/plovr/blob/master/src/org/plovr/test.soy">test.soy</a>
+{sp}and is named <code>org.plovr.test</code>.
 You can specify your own template by using the <a href="options.html#test-template">test-template</a>
 {sp}option in your plovr config. Note that your template must be defined in its
 own Soy file, and must also be named <code>org.plovr.test</code>.


### PR DESCRIPTION
Wiki links still point to code.google.com, since those were not migrated (yet).