### PR TITLE
exclude closure-library tests from resources

### DIFF
--- a/closure/closure-library/BUCK
+++ b/closure/closure-library/BUCK
@@ -2,9 +2,7 @@
 java_library(
   name = 'closure-library',
   srcs = [],
-  resources = glob(includes=[
-    '**/*.js'
-  ]),
+  resources = glob(includes=['**/*.js'], excludes=['**/*_test.js']),
   resources_root = '.',
   visibility = [
     'PUBLIC',


### PR DESCRIPTION
Hello @nicks, 

Please review the following commits I made in branch 'nick-closureLib'.

01ec2870f22742ae2365c382a5b5c68dfeea05bd (2015-10-20 21:57:11 -0700)
exclude closure-library tests from resources

91f801e8ac9009ea7c1c7a2c799b2dd5a14a761e (2015-10-20 21:50:36 -0700)
bump version number

R=@nicks