### PR TITLE
make location mapping configurable

### DIFF
--- a/src/org/plovr/ConfigOption.java
+++ b/src/org/plovr/ConfigOption.java
@@ -294,6 +294,13 @@ public enum ConfigOption {
     }
   }),
 
+  LOCATION_MAPPING("location-mapping", new ConfigUpdater() {
+    @Override
+    public void apply(JsonObject locationMapping, Config.Builder builder) {
+      builder.setLocationMappings(locationMapping);
+    }
+  }),
+
   MODULES("modules", new ConfigUpdater() {
     @Override
     public void apply(JsonObject modules, Config.Builder builder) {


### PR DESCRIPTION
In all source maps is: /input/[module-name]/ set as prefix for __file__ and __sources__  
This was reported in: http://code.google.com/p/closure-compiler/issues/detail?id=770  

made it configurable via config:
```
"location-mapping" : {
	"" : "/input%s/"
},
```
Whereas %s is replaced by the module name. Having no configuration sets no prefix