### PR TITLE
Translation support

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="closure/closure-library"/>
 	<classpathentry kind="src" path="closure/closure-stylesheets/build/genfiles/java"/>
 	<classpathentry kind="src" path="closure/closure-stylesheets/src"/>
 	<classpathentry kind="src" path="closure/closure-templates/build/genfiles"/>

--- a/closure/closure-compiler/src/com/google/javascript/jscomp/JsMessage.java
+++ b/closure/closure-compiler/src/com/google/javascript/jscomp/JsMessage.java
@@ -164,7 +164,7 @@ public final class JsMessage {
    * Gets the meaning annotated to the message, intended to force different
    * translations.
    */
-  String getMeaning() {
+  public String getMeaning() {
     return meaning;
   }
 

--- a/src/org/plovr/Config.java
+++ b/src/org/plovr/Config.java
@@ -33,12 +33,15 @@ import com.google.javascript.jscomp.SourceMap.LocationMapping;
 import com.google.javascript.jscomp.StrictWarningsGuard;
 import com.google.javascript.jscomp.VariableMap;
 import com.google.javascript.jscomp.WarningLevel;
+import com.google.javascript.jscomp.XtbMessageBundle;
 import com.google.template.soy.xliffmsgplugin.XliffMsgPluginModule;
 
 import org.plovr.util.Pair;
 import org.plovr.webdriver.WebDriverFactory;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Field;
@@ -179,6 +182,10 @@ public final class Config implements Comparable<Config> {
   private final String gssFunctionMapProviderClassName;
 
   private final File cssOutputFile;
+  
+  private final File translationsDirectory;
+  
+  private final String language;
 
   private final JobDescription.OutputFormat cssOutputFormat;
 
@@ -243,7 +250,9 @@ public final class Config implements Comparable<Config> {
       File cssOutputFile,
       JobDescription.OutputFormat cssOutputFormat,
       PrintStream errorStream,
-      List<LocationMapping> locationMappings) {
+      List<LocationMapping> locationMappings,
+      File translationsDirectory,
+      String language) {
     Preconditions.checkNotNull(defines);
 
     this.id = id;
@@ -299,6 +308,8 @@ public final class Config implements Comparable<Config> {
     this.cssOutputFormat = cssOutputFormat;
     this.errorStream = Preconditions.checkNotNull(errorStream);
     this.locationMappings = locationMappings;
+    this.translationsDirectory = translationsDirectory;
+    this.language = language;
   }
 
   public static Builder builder(File relativePathBase, File configFile,
@@ -581,6 +592,14 @@ public final class Config implements Comparable<Config> {
   public List<WebDriverFactory> getWebDriverFactories() {
     return ImmutableList.copyOf(testDrivers);
   }
+  
+  public File getTranslationsDirectory() {
+	  return translationsDirectory;
+  }
+  
+  public String getLanguage() {
+	  return language;
+  }
 
   /**
    * @param path a relative path, such as "foo/bar_test.js" or
@@ -754,6 +773,24 @@ public final class Config implements Comparable<Config> {
     }
 
     options.setExternExports(true);
+    
+    if (translationsDirectory != null && language != null) {
+    	try {
+    		File[] files = translationsDirectory.listFiles(new FilenameFilter() {
+    			@Override public boolean accept(File dir, String name) {
+    				return name.startsWith(language) && name.endsWith(".xtb");
+    			}
+    	    });
+    	    if (files.length == 0) {
+    	    	logger.severe("Unable to find translations file for " + language);
+    	    } else {
+    	    	options.setMessageBundle(
+    	    		new XtbMessageBundle(new FileInputStream(files[0]), null));
+    	    }
+    	} catch (IOException e) {
+    		logger.severe("Unable to load translations file: " + e.getMessage());
+    	}
+    }
 
     // Add location mapping for paths in source map.
     options.setSourceMapLocationMappings(locationMappings);
@@ -1063,6 +1100,10 @@ public final class Config implements Comparable<Config> {
 
     private File cssOutputFile = null;
 
+    private File translationsDirectory = null;
+
+    private String language = null;
+
     private JobDescription.OutputFormat cssOutputFormat = JobDescription.OutputFormat.PRETTY_PRINTED;
 
     private PrintStream errorStream = System.err;
@@ -1154,6 +1195,8 @@ public final class Config implements Comparable<Config> {
       this.gssFunctionMapProviderClassName = config.
           gssFunctionMapProviderClassName;
       this.cssOutputFile = config.cssOutputFile;
+      this.translationsDirectory = config.translationsDirectory;
+      this.language = config.language;
       this.cssOutputFormat = config.cssOutputFormat;
       this.errorStream = config.errorStream;
     }
@@ -1562,6 +1605,14 @@ public final class Config implements Comparable<Config> {
     public void setCssOutputFile(File cssOutputFile) {
       this.cssOutputFile = cssOutputFile;
     }
+    
+    public void setTranslationsDirectory(File translationsDirectory) {
+    	this.translationsDirectory = translationsDirectory;
+    }
+
+    public void setLanguage(String language) {
+    	this.language = language;
+    }
 
     public void setCssOutputFormat(JobDescription.OutputFormat cssOutputFormat) {
       this.cssOutputFormat = cssOutputFormat;
@@ -1664,7 +1715,9 @@ public final class Config implements Comparable<Config> {
           cssOutputFile,
           cssOutputFormat,
           errorStream,
-          locationMappings);
+          locationMappings,
+          translationsDirectory,
+          language);
 
       return config;
     }

--- a/src/org/plovr/Config.java
+++ b/src/org/plovr/Config.java
@@ -778,14 +778,22 @@ public final class Config implements Comparable<Config> {
     	try {
     		File[] files = translationsDirectory.listFiles(new FilenameFilter() {
     			@Override public boolean accept(File dir, String name) {
-    				return name.startsWith(language) && name.endsWith(".xtb");
+    				return name.startsWith(language) && (
+    						name.endsWith(".xtb") ||
+    						name.endsWith(".xliff") ||
+    						name.endsWith(".xlf"));
     			}
     	    });
     	    if (files.length == 0) {
     	    	logger.severe("Unable to find translations file for " + language);
     	    } else {
-    	    	options.setMessageBundle(
-    	    		new XtbMessageBundle(new FileInputStream(files[0]), null));
+    	    	if (files[0].getName().endsWith(".xtb")) {
+    	    		options.setMessageBundle(
+    	    				new XtbMessageBundle(new FileInputStream(files[0]), null));
+    	    	} else {
+    	    		options.setMessageBundle(
+    	    				new XliffMessageBundle(new FileInputStream(files[0]), null));
+    	    	}
     	    }
     	} catch (IOException e) {
     		logger.severe("Unable to load translations file: " + e.getMessage());

--- a/src/org/plovr/ConfigOption.java
+++ b/src/org/plovr/ConfigOption.java
@@ -864,6 +864,29 @@ public enum ConfigOption {
       return true;
     }
   }),
+
+  TRANSLATIONS("translations", new ConfigUpdater() {
+    @Override
+    public void apply(String translations, Config.Builder builder) {
+      File dir = (translations == null) ? null :
+          new File(maybeResolvePath(translations, builder));
+      builder.setTranslationsDirectory(dir);
+    }
+  }),
+
+  LANGUAGE("language", new ConfigUpdater() {
+    @Override
+    public void apply(String language, Config.Builder builder) {
+      builder.setLanguage(language);
+    }
+
+    @Override
+    public boolean update(String mode, Config.Builder builder) {
+      apply(mode, builder);
+      return true;
+    }
+  }),
+
   ;
 
   private static class ConfigUpdater {

--- a/src/org/plovr/SoyFile.java
+++ b/src/org/plovr/SoyFile.java
@@ -49,6 +49,9 @@ public class SoyFile extends LocalFileJsInput {
       value.setShouldProvideRequireSoyNamespaces(options.useClosureLibrary);
       value.setShouldDeclareTopLevelNamespaces(options.useClosureLibrary);
       value.setIsUsingIjData(options.isUsingInjectedData);
+      value.setShouldGenerateGoogMsgDefs(options.useClosureLibrary);
+      value.setUseGoogIsRtlForBidiGlobalDir(options.useClosureLibrary);
+
       jsSrcOptionsMap.put(options, value);
     }
 

--- a/src/org/plovr/XliffMessageBundle.java
+++ b/src/org/plovr/XliffMessageBundle.java
@@ -1,0 +1,78 @@
+package org.plovr;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Charsets;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.google.common.io.ByteStreams;
+import com.google.javascript.jscomp.GoogleJsMessageIdGenerator;
+import com.google.javascript.jscomp.JsMessage;
+import com.google.javascript.jscomp.MessageBundle;
+import com.google.template.soy.msgs.SoyMsgBundle;
+import com.google.template.soy.msgs.restricted.SoyMsg;
+import com.google.template.soy.msgs.restricted.SoyMsgPart;
+import com.google.template.soy.msgs.restricted.SoyMsgPlaceholderPart;
+import com.google.template.soy.msgs.restricted.SoyMsgRawTextPart;
+import com.google.template.soy.xliffmsgplugin.XliffMsgPlugin;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+public class XliffMessageBundle implements MessageBundle {
+
+  private final Map<String, JsMessage> messages;
+  private final JsMessage.IdGenerator idGenerator;
+
+  public XliffMessageBundle(InputStream xliff, @Nullable String projectId) {
+    Preconditions.checkState(!"".equals(projectId));
+    this.messages = Maps.newHashMap();
+    this.idGenerator = new GoogleJsMessageIdGenerator(projectId);
+
+    SoyMsgBundle bundle;
+    try {
+      // TODO: Figure out charset?
+      bundle = new XliffMsgPlugin().parseTranslatedMsgsFile(
+        new String(ByteStreams.toByteArray(xliff), Charsets.UTF_8));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    for (SoyMsg msg : bundle) {
+      JsMessage.Builder builder = new JsMessage.Builder(String.valueOf(msg.getId()));
+      if (msg.getMeaning() != null) {
+        builder.setMeaning(msg.getMeaning());
+      }
+      for (SoyMsgPart part : msg.getParts()) {
+        if (part instanceof SoyMsgRawTextPart) {
+          builder.appendStringPart(((SoyMsgRawTextPart)part).getRawText());
+        } else if (part instanceof SoyMsgPlaceholderPart) {
+          builder.appendPlaceholderReference(
+            ((SoyMsgPlaceholderPart)part).getPlaceholderName());
+        } else {
+          Preconditions.checkState(
+            false,
+            "Unknown message part type: " + part.getClass().getSimpleName());
+        }
+      }
+      messages.put(builder.getKey(), builder.build());
+    }
+  }
+
+  @Override
+  public JsMessage getMessage(String id) {
+    return messages.get(id);
+  }
+
+  @Override
+  public JsMessage.IdGenerator idGenerator() {
+    return idGenerator;
+  }
+
+  @Override
+  public Iterable<JsMessage> getAllMessages() {
+    return Iterables.unmodifiableIterable(messages.values());
+  }
+}

--- a/src/org/plovr/cli/BuildCommand.java
+++ b/src/org/plovr/cli/BuildCommand.java
@@ -51,7 +51,11 @@ public class BuildCommand extends AbstractCommandRunner<BuildCommandOptions> {
     }
 
     for (String configFile: arguments) {
-      Config config = ConfigParser.parseFile(new File(configFile));
+      Config.Builder builder = ConfigParser.createBuilderFromFile(new File(configFile));
+      if (options.getLanguage() != null) {
+        builder.setLanguage(options.getLanguage());
+      }
+      Config config = builder.build();
       Compilation compilation;
       try {
         compilation = Compilation.createAndCompile(config);

--- a/src/org/plovr/cli/BuildCommandOptions.java
+++ b/src/org/plovr/cli/BuildCommandOptions.java
@@ -13,11 +13,19 @@ public class BuildCommandOptions extends AbstractCommandOptions {
       usage = "Specifies the path where the source map for the compilation should be written")
   private String sourceMapPath = null;
 
+  @Option(name = "--language",
+      usage = "Specifies the language to use for translations.")
+  private String language = null;
+
   @Argument
   private List<String> arguments = Lists.newLinkedList();
 
   public String getSourceMapPath() {
     return sourceMapPath;
+  }
+
+  public String getLanguage() {
+    return language;
   }
 
   public List<String> getArguments() {

--- a/src/org/plovr/cli/ExtractCommandOptions.java
+++ b/src/org/plovr/cli/ExtractCommandOptions.java
@@ -3,6 +3,7 @@ package org.plovr.cli;
 import java.util.List;
 
 import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.Option;
 
 import com.google.common.collect.Lists;
 
@@ -11,7 +12,15 @@ public class ExtractCommandOptions extends AbstractCommandOptions {
   @Argument
   private List<String> arguments = Lists.newLinkedList();
 
+  @Option(name="--format",
+      usage="Specifies the output message file format")
+  private ExtractCommand.Format format = ExtractCommand.Format.XTB;
+
   public List<String> getArguments() {
     return arguments;
+  }
+
+  public ExtractCommand.Format getFormat() {
+    return format;
   }
 }

--- a/testdata/translation/config.js
+++ b/testdata/translation/config.js
@@ -1,0 +1,10 @@
+{
+  "id": "translation-test",
+  "paths": ["."],
+  "inputs": "main.js",
+
+  "mode": "ADVANCED",
+
+  "translations": ".",
+  "language": "en"
+}

--- a/testdata/translation/fr.xtb
+++ b/testdata/translation/fr.xtb
@@ -1,0 +1,5 @@
+<translationbundle lang="fr">
+<translation id="6509454819323371482">Bonjour, <ph name="USER_NAME"/>!</translation>
+<translation id="1367515969960147191">Testeur</translation>
+<translation id="8325070479083159428">Bonjour au monde!</translation>
+</translationbundle>

--- a/testdata/translation/main.js
+++ b/testdata/translation/main.js
@@ -1,0 +1,24 @@
+goog.provide('translation.main');
+
+goog.require('translation.templates');
+
+goog.require('goog.ui.Tooltip');
+goog.require('soy');
+
+
+translation.main = function() {
+  /** @desc Name */
+  var MSG_TESTER = goog.getMsg('Tester');
+  var soyData = {
+    userName: MSG_TESTER
+  };
+  var fragment = soy.renderAsFragment(translation.templates.base, soyData);
+  document.body.appendChild(fragment);
+  /** @desc Greeting */
+  var MSG_HELLO_WORLD = goog.getMsg('Hello World!');
+  var tooltip = new goog.ui.Tooltip(fragment, MSG_HELLO_WORLD);
+};
+
+translation.main();
+
+goog.addDependency('/dev/null', ['goog.debug.ErrorHandler'], []);

--- a/testdata/translation/ru.xliff
+++ b/testdata/translation/ru.xliff
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="SoyMsgBundle" datatype="x-soy-msg-bundle" xml:space="preserve" source-language="en">
+    <body>
+      <trans-unit id="1367515969960147191">
+        <source>Tester</source>
+        <target>Тестер</target>
+        <note priority="1" from="description">Name</note>
+      </trans-unit>
+      <trans-unit id="6216300906735613473">
+        <source>Hello, <x id="user"/>!</source>
+        <target>Привет, <x id="user"/>!</target>
+        <note priority="1" from="description">hello for user</note>
+      </trans-unit>
+      <trans-unit id="8325070479083159428">
+        <source>Hello World!</source>
+        <target>Привет, мир!</target>
+        <note priority="1" from="description">Greeting</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/testdata/translation/templates.soy
+++ b/testdata/translation/templates.soy
@@ -1,0 +1,8 @@
+{namespace translation.templates}
+
+/**
+ * @param userName
+ */
+{template .base}
+<div>{msg desc="hello for user"}Hello, {$userName}!{/msg}</div>
+{/template}

--- a/testdata/translation/test-simple.html
+++ b/testdata/translation/test-simple.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+  <title>Test for SIMPLE mode with fr translations</title>
+  <style>
+    .goog-tooltip {
+      background: infobackground;
+      color: infotext;
+      border: 1px solid infotext;
+      padding: 1px;
+      font: menu;
+    }
+  </style>
+</head>
+<body>
+
+  <script src="http://localhost:9818/compile?id=translation-test&mode=SIMPLE&language=fr"></script>
+
+</body>
+</html>


### PR DESCRIPTION
Implement translation support.

All credit goes to @imirkin.

The two original patches,

https://codereview.appspot.com/6194048/
https://codereview.appspot.com/6201051/

implement support for extracting XTB and XLIFF translation files. XTB extraction was already implemented but there was no support for consuming translated files of either format.

The patches make two new plovr configs available: `translations`, which takes a string for the path to the translation files, and `language`, which sets the language to use.