### PR TITLE
* Adds the 'cache-output-file` configuration option.

### DIFF
--- a/src/org/plovr/Compilation.java
+++ b/src/org/plovr/Compilation.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import javax.annotation.Nullable;
 
@@ -46,6 +47,8 @@ import com.google.template.soy.base.SoySyntaxException;
  * @author bolinfest@gmail.com (Michael Bolin)
  */
 public final class Compilation {
+
+  private static final Logger logger = Logger.getLogger("org.plovr.Compilation");
 
   private final List<SourceFile> externs;
   private final List<SourceFile> inputs;
@@ -112,6 +115,8 @@ public final class Compilation {
       PlovrClosureCompiler dummyCompiler = new PlovrClosureCompiler(config.getErrorStream());
       Compilation compilation = config.getManifest().getCompilerArguments(
           config.getModuleConfig(), config.getCompilerOptions(dummyCompiler));
+      logger.info("Compiling " + allDependencies.size()
+                  + " dependencies using mode: " + config.getCompilationMode());
       compilation.compile(config);
       return compilation;
     } catch (Throwable e) {

--- a/src/org/plovr/CompileRequestHandler.java
+++ b/src/org/plovr/CompileRequestHandler.java
@@ -99,6 +99,7 @@ public class CompileRequestHandler extends AbstractGetHandler {
       Appendable appendable) throws IOException, CompilationException {
     Compilation compilation;
     String viewSourceUrl = getViewSourceUrlForExchange(exchange);
+
     try {
       compilation = Compilation.createAndCompile(config);
     } catch (CompilationException e) {

--- a/src/org/plovr/CompileRequestHandler.java
+++ b/src/org/plovr/CompileRequestHandler.java
@@ -4,6 +4,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -17,6 +18,7 @@ import com.sun.net.httpserver.HttpExchange;
 
 import org.plovr.io.Responses;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
@@ -51,13 +53,22 @@ public class CompileRequestHandler extends AbstractGetHandler {
     StringBuilder builder = new StringBuilder();
 
     try {
+      Manifest manifest = config.getManifest();
       if (config.getCompilationMode() == CompilationMode.RAW) {
-        Manifest manifest = config.getManifest();
         String js = InputFileHandler.getJsToLoadManifest(
-            server, config, manifest, exchange);
+          server, config, manifest, exchange);
         builder.append(js);
       } else {
-        compile(config, exchange, builder);
+        if (needsRecompile(config)) {
+          compile(config, exchange, builder);
+        } else {
+          File tmp = config.getCacheOutputFile();
+          String cachedJs = Files.toString(tmp, config.getOutputCharset());
+          builder.append(cachedJs);
+          logger.info("JS Recompile skipped. Served "
+                      + FileUtil.humanReadableByteCount(tmp.length(), true)
+                      + " from cache <" + tmp + '>');
+        }
       }
     } catch (CompilationException e) {
       Preconditions.checkState(builder.length() == 0,
@@ -130,6 +141,15 @@ public class CompileRequestHandler extends AbstractGetHandler {
       } else {
         appendable.append(compilation.getCompiledCode());
       }
+
+      // Here at the end of a successful compilation.  If the
+      // cache-output-file has been defined, save compiled js out to it.
+      File cacheOutputFile = config.getCacheOutputFile();
+      if (cacheOutputFile != null) {
+          cacheOutputFile.getParentFile().mkdirs();
+          Files.write(appendable.toString(), cacheOutputFile, config.getOutputCharset());
+      }
+
     }
 
     // TODO(bolinfest): Check whether writing out the plovr library confuses the
@@ -149,4 +169,54 @@ public class CompileRequestHandler extends AbstractGetHandler {
   private String getViewSourceUrlForExchange(HttpExchange exchange) {
     return server.getServerForExchange(exchange) + "view";
   }
+
+  /**
+   * Return true if (1) the tmp file does not exist, (2) the config
+   * file or any local file dependencies are newer than the tmp file.
+   *
+   * @author Paul Johnston (pcj@pubref.org)
+   */
+  protected boolean needsRecompile(Config config) throws CompilationException {
+    File cacheOutputFile = config.getCacheOutputFile();
+
+    if (cacheOutputFile == null) {
+      return true;
+    }
+
+    if (!cacheOutputFile.exists()) {
+      logger.info("JS Recompile required (cache-output-file not found): " + cacheOutputFile);
+      return true;
+    }
+
+    long lastModified = cacheOutputFile.lastModified();
+
+    if (config.isOutOfDate() || FileUtil.isNewer(config.getConfigFile(), lastModified)) {
+      logger.info("JS Recompile required (config-file newer): " + config.getConfigFile());
+      return true;
+    }
+
+    Manifest manifest = config.getManifest();
+    List<JsInput> inputs = manifest.getInputsInCompilationOrder();
+    for (JsInput input : inputs) {
+      if (input instanceof LocalFileJsInput) {
+        File source = ((LocalFileJsInput)input).getSource();
+        if (FileUtil.isNewer(source, lastModified)) {
+          logger.info("JS Recompile required (found newer file): " + source);
+          return true;
+        }
+      } else if (input instanceof ResourceJsInput) {
+        // assume these are up to date.
+        continue;
+      } else if (input.toString().startsWith("/closure/goog")) {
+        // assume these are up to date.
+        continue;
+      } else {
+        logger.info("JS Recompile required (found non-localfile-input): " + input + " of type " + input.getClass().getName());
+        return true;
+      }
+    }
+
+    return false;
+  }
+
 }

--- a/src/org/plovr/Config.java
+++ b/src/org/plovr/Config.java
@@ -119,6 +119,8 @@ public final class Config implements Comparable<Config> {
 
   private final Charset outputCharset;
 
+  private final File cacheOutputFile;
+
   private final boolean fingerprintJsFiles;
 
   private final Map<String, CheckLevel> checkLevelsForDiagnosticGroups;
@@ -217,6 +219,7 @@ public final class Config implements Comparable<Config> {
       @Nullable File outputFile,
       @Nullable String outputWrapper,
       Charset outputCharset,
+      @Nullable File cacheOutputFile,
       boolean fingerprintJsFiles,
       Map<String, CheckLevel> checkLevelsForDiagnosticGroups,
       boolean exportTestFunctions,
@@ -272,6 +275,7 @@ public final class Config implements Comparable<Config> {
     this.outputFile = outputFile;
     this.outputWrapper = outputWrapper;
     this.outputCharset = outputCharset;
+    this.cacheOutputFile = cacheOutputFile;
     this.fingerprintJsFiles = fingerprintJsFiles;
     this.checkLevelsForDiagnosticGroups = checkLevelsForDiagnosticGroups;
     this.exportTestFunctions = exportTestFunctions;
@@ -373,6 +377,10 @@ public final class Config implements Comparable<Config> {
 
   public File getOutputFile() {
     return outputFile;
+  }
+
+  public File getCacheOutputFile() {
+      return cacheOutputFile;
   }
 
   /**
@@ -1052,6 +1060,8 @@ public final class Config implements Comparable<Config> {
 
     private File outputFile = null;
 
+    private File cacheOutputFile = null;
+
     private String outputWrapper = null;
 
     private Charset outputCharset = Charsets.US_ASCII;
@@ -1179,6 +1189,7 @@ public final class Config implements Comparable<Config> {
       this.outputFile = config.outputFile;
       this.outputWrapper = config.outputWrapper;
       this.outputCharset = config.outputCharset;
+      this.cacheOutputFile = config.cacheOutputFile;
       this.fingerprintJsFiles = config.fingerprintJsFiles;
       this.checkLevelsForDiagnosticGroups = config.checkLevelsForDiagnosticGroups;
       this.exportTestFunctions = config.exportTestFunctions;
@@ -1431,6 +1442,10 @@ public final class Config implements Comparable<Config> {
 
     public void setOutputFile(File outputFile) {
       this.outputFile = outputFile;
+    }
+
+    public void setCacheOutputFile(File cacheOutputFile) {
+      this.cacheOutputFile = cacheOutputFile;
     }
 
     public void setOutputWrapper(String outputWrapper) {
@@ -1696,6 +1711,7 @@ public final class Config implements Comparable<Config> {
           outputFile,
           outputWrapper,
           outputCharset,
+          cacheOutputFile,
           fingerprintJsFiles,
           checkLevelsForDiagnosticGroups,
           exportTestFunctions,

--- a/src/org/plovr/Config.java
+++ b/src/org/plovr/Config.java
@@ -639,7 +639,6 @@ public final class Config implements Comparable<Config> {
     Preconditions.checkArgument(compilationMode != CompilationMode.RAW,
         "Cannot compile using RAW mode");
     CompilationLevel level = compilationMode.getCompilationLevel();
-    logger.info("Compiling with level: " + level);
     PlovrCompilerOptions options = new PlovrCompilerOptions();
 
     options.setTreatWarningsAsErrors(getTreatWarningsAsErrors());
@@ -1060,6 +1059,8 @@ public final class Config implements Comparable<Config> {
 
     private File outputFile = null;
 
+    private boolean useCacheOutputFile = true;
+
     private File cacheOutputFile = null;
 
     private String outputWrapper = null;
@@ -1189,6 +1190,7 @@ public final class Config implements Comparable<Config> {
       this.outputFile = config.outputFile;
       this.outputWrapper = config.outputWrapper;
       this.outputCharset = config.outputCharset;
+      this.useCacheOutputFile = config.cacheOutputFile != null;
       this.cacheOutputFile = config.cacheOutputFile;
       this.fingerprintJsFiles = config.fingerprintJsFiles;
       this.checkLevelsForDiagnosticGroups = config.checkLevelsForDiagnosticGroups;
@@ -1448,6 +1450,10 @@ public final class Config implements Comparable<Config> {
       this.cacheOutputFile = cacheOutputFile;
     }
 
+    public void setUseCacheOutputFile(boolean useCacheOutputFile) {
+      this.useCacheOutputFile = useCacheOutputFile;
+    }
+
     public void setOutputWrapper(String outputWrapper) {
       this.outputWrapper = outputWrapper;
     }
@@ -1691,6 +1697,14 @@ public final class Config implements Comparable<Config> {
             customExternsOnly);
       } else {
         manifest = this.manifest;
+      }
+
+      // For the plovr serve command, create a default
+      // cache-output-file if none has been assigned UNLESS the user
+      // has specifically suppressed this with the
+      // 'cache-output-file=none' configuration.
+      if (cacheOutputFile == null && useCacheOutputFile) {
+        cacheOutputFile = FileUtil.getTmpFile("plovr-serve-cache.js");
       }
 
       Config config = new Config(

--- a/src/org/plovr/ConfigOption.java
+++ b/src/org/plovr/ConfigOption.java
@@ -272,6 +272,16 @@ public enum ConfigOption {
     }
   }),
 
+
+  CACHE_OUTPUT_FILE("cache-output-file", new ConfigUpdater() {
+    @Override
+    public void apply(String outputFilePath, Config.Builder builder) {
+      File outputFile = (outputFilePath == null) ? null :
+        new File(maybeResolvePath(outputFilePath, builder));
+      builder.setCacheOutputFile(outputFile);
+    }
+  }),
+
   LANGUAGE_IN("language-in", new ConfigUpdater() {
     @Override
     public void apply(String mode, Config.Builder builder) {

--- a/src/org/plovr/ConfigOption.java
+++ b/src/org/plovr/ConfigOption.java
@@ -276,9 +276,15 @@ public enum ConfigOption {
   CACHE_OUTPUT_FILE("cache-output-file", new ConfigUpdater() {
     @Override
     public void apply(String outputFilePath, Config.Builder builder) {
-      File outputFile = (outputFilePath == null) ? null :
-        new File(maybeResolvePath(outputFilePath, builder));
-      builder.setCacheOutputFile(outputFile);
+      // If the outputFilePath value is "none", disable use of the
+      // cache.
+      if ("none".equals(outputFilePath)) {
+        builder.setUseCacheOutputFile(false);
+      } else {
+        File outputFile = (outputFilePath == null) ? null :
+          new File(maybeResolvePath(outputFilePath, builder));
+        builder.setCacheOutputFile(outputFile);
+      }
     }
   }),
 

--- a/src/org/plovr/FileUtil.java
+++ b/src/org/plovr/FileUtil.java
@@ -32,8 +32,6 @@ public final class FileUtil {
   /**
    * Return true if the file argument is non-null and has a
    * last-modified date greater than the given lastModified time.
-   *
-   * @author pcj@pubref.org (Paul Johnston)
    */
   public static boolean isNewer(File file, long lastModified) {
     if (file == null) {
@@ -44,7 +42,6 @@ public final class FileUtil {
 
 
   /**
-   * @author pcj@pubref.org (Paul Johnston)
    * @see http://stackoverflow.com/questions/3758606/how-to-convert-byte-size-into-human-readable-format-in-java
    */
   public static String humanReadableByteCount(long bytes, boolean si) {
@@ -57,5 +54,13 @@ public final class FileUtil {
     return String.format("%.1f %sB", bytes / Math.pow(unit, exp), pre);
   }
 
+
+  /**
+   * Return a File in the <code>java.io.tmpdir</code> having the given
+   * name.
+   */
+  public static File getTmpFile(String filename) {
+    return new File(System.getProperty("java.io.tmpdir"), filename);
+  }
 
 }

--- a/src/org/plovr/FileUtil.java
+++ b/src/org/plovr/FileUtil.java
@@ -27,4 +27,35 @@ public final class FileUtil {
 
     return false;
   }
+
+
+  /**
+   * Return true if the file argument is non-null and has a
+   * last-modified date greater than the given lastModified time.
+   *
+   * @author pcj@pubref.org (Paul Johnston)
+   */
+  public static boolean isNewer(File file, long lastModified) {
+    if (file == null) {
+      return false;
+    }
+    return file.lastModified() > lastModified;
+  }
+
+
+  /**
+   * @author pcj@pubref.org (Paul Johnston)
+   * @see http://stackoverflow.com/questions/3758606/how-to-convert-byte-size-into-human-readable-format-in-java
+   */
+  public static String humanReadableByteCount(long bytes, boolean si) {
+    int unit = si ? 1000 : 1024;
+    if (bytes < unit) {
+      return bytes + " B";
+    }
+    int exp = (int) (Math.log(bytes) / Math.log(unit));
+    String pre = (si ? "kMGTPE" : "KMGTPE").charAt(exp-1) + (si ? "" : "i");
+    return String.format("%.1f %sB", bytes / Math.pow(unit, exp), pre);
+  }
+
+
 }


### PR DESCRIPTION
* If defined, the `plovr serve` command will write the
  output of a successful compilation run to this file.
  Subsequent GET requests to the serve command will respond
  with the contents of this file rather than attempt
  recompile.  A recompile will be triggered if any compile
  dependencies are modified.