### PR TITLE
Aggressive cache

### DIFF
--- a/src/org/plovr/AbstractGetHandler.java
+++ b/src/org/plovr/AbstractGetHandler.java
@@ -105,14 +105,25 @@ abstract class AbstractGetHandler implements HttpHandler {
   }
 
   /**
+   * Formats a date for an HTTP header.
+   */
+  protected static String formatDate(Date date) {
+    DateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
+    format.setTimeZone(TimeZone.getTimeZone("GMT"));
+    return format.format(date);
+  }
+
+  protected void setDateHeader(Headers headers) {
+    headers.set("Date", formatDate(new Date()));
+  }
+
+  /**
    * Sets the cache headers to disable caching of resources.
    * See http://code.google.com/p/doctype/wiki/ArticleHttpCaching
    */
   protected void setCacheHeaders(Headers headers) {
-    DateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
-    format.setTimeZone(TimeZone.getTimeZone("GMT"));
+    setDateHeader(headers);
 
-    headers.set("Date", format.format(new Date()));
     headers.set("Expires", "Fri, 01 Jan 1990 00:00:00 GMT");
     headers.set("Pragma", "no-cache");
     headers.set("Cache-control", "no-cache, must-revalidate");

--- a/src/org/plovr/Config.java
+++ b/src/org/plovr/Config.java
@@ -121,6 +121,8 @@ public final class Config implements Comparable<Config> {
 
   private final boolean printInputDelimiter;
 
+  private final boolean enableAggressiveRawCaching;
+
   private final File outputFile;
 
   private final String outputWrapper;
@@ -225,6 +227,7 @@ public final class Config implements Comparable<Config> {
       boolean debug,
       boolean prettyPrint,
       boolean printInputDelimiter,
+      boolean enableAggressiveRawCaching,
       @Nullable File outputFile,
       @Nullable String outputWrapper,
       Charset outputCharset,
@@ -282,6 +285,7 @@ public final class Config implements Comparable<Config> {
     this.debug = debug;
     this.prettyPrint = prettyPrint;
     this.printInputDelimiter = printInputDelimiter;
+    this.enableAggressiveRawCaching = enableAggressiveRawCaching;
     this.outputFile = outputFile;
     this.outputWrapper = outputWrapper;
     this.outputCharset = outputCharset;
@@ -383,6 +387,10 @@ public final class Config implements Comparable<Config> {
 
   public WarningLevel getWarningLevel() {
     return warningLevel;
+  }
+
+  public boolean getEnableAggressiveRawCaching() {
+    return enableAggressiveRawCaching;
   }
 
   public File getOutputFile() {
@@ -1092,6 +1100,8 @@ public final class Config implements Comparable<Config> {
 
     private boolean printInputDelimiter = false;
 
+    private boolean enableAggressiveRawCaching = false;
+
     private File outputFile = null;
 
     private File cacheOutputFile = null;
@@ -1221,6 +1231,7 @@ public final class Config implements Comparable<Config> {
       this.debug = config.debug;
       this.prettyPrint = config.prettyPrint;
       this.printInputDelimiter = config.printInputDelimiter;
+      this.enableAggressiveRawCaching = config.enableAggressiveRawCaching;
       this.outputFile = config.outputFile;
       this.outputWrapper = config.outputWrapper;
       this.outputCharset = config.outputCharset;
@@ -1502,6 +1513,10 @@ public final class Config implements Comparable<Config> {
 
     public void setPrintInputDelimiter(boolean printInputDelimiter) {
       this.printInputDelimiter = printInputDelimiter;
+    }
+
+    public void setEnableAggressiveRawCaching(boolean enableAggressiveRawCaching) {
+      this.enableAggressiveRawCaching = enableAggressiveRawCaching;
     }
 
     public void setOutputFile(File outputFile) {
@@ -1801,6 +1816,7 @@ public final class Config implements Comparable<Config> {
           debug,
           prettyPrint,
           printInputDelimiter,
+          enableAggressiveRawCaching,
           outputFile,
           outputWrapper,
           outputCharset,

--- a/src/org/plovr/ConfigOption.java
+++ b/src/org/plovr/ConfigOption.java
@@ -208,13 +208,6 @@ public enum ConfigOption {
     }
   }),
 
-  ENABLE_AGGRESSIVE_RAW_CACHING("enable-aggressive-raw-caching", new ConfigUpdater() {
-    @Override
-    public void apply(boolean enableAggressiveRawCaching, Config.Builder builder) {
-      builder.setEnableAggressiveRawCaching(enableAggressiveRawCaching);
-    }
-  }),
-
   SOURCE_MAP_BASE_URL("source-map-base-url", new ConfigUpdater() {
     @Override
     public void apply(String sourceMapBaseUrl, Config.Builder builder) {
@@ -562,6 +555,17 @@ public enum ConfigOption {
     public boolean reset(Config.Builder builder) {
       builder.resetExperimentalCompilerOptions();
       return true;
+    }
+  }),
+
+  /**
+   * Set long Expires and Cache-Control: max-age headers on files served in RAW
+   * mode.
+   */
+  ENABLE_AGGRESSIVE_RAW_CACHING("enable-aggressive-raw-caching", new ConfigUpdater() {
+    @Override
+    public void apply(boolean enableAggressiveRawCaching, Config.Builder builder) {
+      builder.setEnableAggressiveRawCaching(enableAggressiveRawCaching);
     }
   }),
 

--- a/src/org/plovr/ConfigOption.java
+++ b/src/org/plovr/ConfigOption.java
@@ -208,6 +208,13 @@ public enum ConfigOption {
     }
   }),
 
+  ENABLE_AGGRESSIVE_RAW_CACHING("enable-aggressive-raw-caching", new ConfigUpdater() {
+    @Override
+    public void apply(boolean enableAggressiveRawCaching, Config.Builder builder) {
+      builder.setEnableAggressiveRawCaching(enableAggressiveRawCaching);
+    }
+  }),
+
   SOURCE_MAP_BASE_URL("source-map-base-url", new ConfigUpdater() {
     @Override
     public void apply(String sourceMapBaseUrl, Config.Builder builder) {

--- a/src/org/plovr/InputFileHandler.java
+++ b/src/org/plovr/InputFileHandler.java
@@ -275,10 +275,10 @@ public class InputFileHandler extends AbstractGetHandler {
     setDateHeader(headers);
 
     Calendar cal = Calendar.getInstance();
-    cal.add(Calendar.SECOND, 315360000);
+    cal.add(Calendar.SECOND, 31536000);
 
     headers.set("Expires", formatDate(cal.getTime()));
-    headers.set("Cache-control", "max-age=315360000");
+    headers.set("Cache-control", "max-age=31536000");
   }
 
   private static final String ETAG_QUERY_PARAM = "_tag";

--- a/src/org/plovr/InputFileHandler.java
+++ b/src/org/plovr/InputFileHandler.java
@@ -21,6 +21,7 @@ import org.plovr.util.HttpExchangeUtil;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -68,7 +69,12 @@ public class InputFileHandler extends AbstractGetHandler {
     // loaded.
    Function<JsInput,JsonPrimitive> inputToUri = Functions.compose(
        GsonUtil.STRING_TO_JSON_PRIMITIVE,
-       createInputNameToUriConverter(server, exchange, config.getId()));
+       createInputNameToUriConverter(
+           server,
+           exchange,
+           config.getId(),
+           (config.getCompilationMode() == CompilationMode.RAW &&
+            config.getEnableAggressiveRawCaching())));
 
     String moduleInfo;
     String moduleUris;
@@ -190,6 +196,11 @@ public class InputFileHandler extends AbstractGetHandler {
         String eTag = codeWithEtag.eTag;
         String ifNoneMatch = exchange.getRequestHeaders().getFirst(
             "If-None-Match");
+        Headers headers = exchange.getResponseHeaders();
+
+        if (data.getParam(ETAG_QUERY_PARAM) != null) {
+          setAggressiveCacheHeaders(headers);
+        }
 
         // Don't send etags on old version of Chrome, because of a weird Java
         // HttpServer bug that it reacted badly to. See:
@@ -199,7 +210,6 @@ public class InputFileHandler extends AbstractGetHandler {
           Responses.notModified(exchange);
           return;
         } else {
-          Headers headers = exchange.getResponseHeaders();
           headers.set("ETag", eTag);
           code = prefix + codeWithEtag.code;
         }
@@ -261,15 +271,29 @@ public class InputFileHandler extends AbstractGetHandler {
   @Override
   protected void setCacheHeaders(Headers headers) {}
 
+  private void setAggressiveCacheHeaders(Headers headers) {
+    setDateHeader(headers);
+
+    Calendar cal = Calendar.getInstance();
+    cal.add(Calendar.SECOND, 315360000);
+
+    headers.set("Expires", formatDate(cal.getTime()));
+    headers.set("Cache-control", "max-age=315360000");
+  }
+
+  private static final String ETAG_QUERY_PARAM = "_tag";
+  private static final Pattern ETAG_PATTERN = Pattern.compile("^W?\"([^\"]+)\"$");
+
   static Function<JsInput, String> createInputNameToUriConverter(
-      CompilationServer server, HttpExchange exchange, final String configId) {
+      CompilationServer server, HttpExchange exchange, final String configId,
+      final boolean includeEtag) {
     String moduleUriBase = server.getServerForExchange(exchange);
-    return createInputNameToUriConverter(moduleUriBase, configId);
+    return createInputNameToUriConverter(moduleUriBase, configId, includeEtag);
   }
 
   @VisibleForTesting
   static Function<JsInput, String> createInputNameToUriConverter(
-      final String moduleUriBase, final String configId) {
+      final String moduleUriBase, final String configId, final boolean includeEtag) {
     return new Function<JsInput, String>() {
       @Override
       public String apply(JsInput input) {
@@ -291,10 +315,18 @@ public class InputFileHandler extends AbstractGetHandler {
         // path information).
         name = escapeRelativePath.apply(name);
 
-        return String.format("%sinput/%s%s",
+        String uri = String.format("%sinput/%s%s",
             moduleUriBase,
             QueryData.encode(configId),
             name);
+
+        if (includeEtag && input.supportsEtags()) {
+            String eTag = input.getCodeWithEtag().eTag;
+            String tag = ETAG_PATTERN.matcher(eTag).replaceAll("$1");
+            uri = String.format("%s?%s=%s", uri, ETAG_QUERY_PARAM, tag);
+        }
+
+        return uri;
       }
     };
   }

--- a/src/org/plovr/ListHandler.java
+++ b/src/org/plovr/ListHandler.java
@@ -63,7 +63,7 @@ public final class ListHandler extends AbstractGetHandler {
 
     // Build up the list of hyperlinks.
     Function<JsInput, String> converter = InputFileHandler
-        .createInputNameToUriConverter(server, exchange, configId);
+        .createInputNameToUriConverter(server, exchange, configId, false);
     SoyListData inputData = new SoyListData();
     for (JsInput input : inputs) {
       SoyMapData inputDatum = new SoyMapData();

--- a/src/org/plovr/options.soy
+++ b/src/org/plovr/options.soy
@@ -451,6 +451,12 @@ window.console.log(z.c());
     "id-generators": ["goog.events.getUniqueId"],
     </pre>
     See p.444 of <a href="{BOOK_URL}">Closure: The Definitive Guide</a> for details.
+  {case 'enable-aggressive-raw-caching'}
+    When <code>RAW</code> is used, Plovr will set long-lived <code>Expires</code>
+    and <code>Cache-Control</code> headers on served files, and will append a
+    hash of file contents to script URL's. The combination enables browsers to not
+    bother to re-request script files that have not changed since they were isLast
+    requested.
   {case 'custom-passes'}
     You can add custom behavior to the Closure Compiler by adding your own
     compiler pass. The standard way to do this is to create a Java class that

--- a/test/org/plovr/DummyJsInput.java
+++ b/test/org/plovr/DummyJsInput.java
@@ -15,6 +15,7 @@ public class DummyJsInput implements JsInput {
 
   private String name;
   private String code;
+  private String etag;
   private List<String> provides;
   private List<String> requires;
   private boolean soyFile;
@@ -22,18 +23,28 @@ public class DummyJsInput implements JsInput {
   long lastModified = 0L;
 
   public DummyJsInput(String name, String code) {
-    this(name, code, null, null, false, null);
+    this(name, code, null, null, false, null, null);
+  }
+
+  public DummyJsInput(String name, String code, String etag) {
+    this(name, code, null, null, false, null, etag);
   }
 
   public DummyJsInput(String name, String code, List<String> provides,
       List<String> requires) {
-    this(name, code, provides, requires, false, null);
+    this(name, code, provides, requires, false, null, null);
   }
 
   public DummyJsInput(String name, String code, List<String> provides,
       List<String> requires, boolean soyFile, String templateCode) {
+    this(name, code, provides, requires, soyFile, templateCode, null);
+  }
+
+  public DummyJsInput(String name, String code, List<String> provides,
+      List<String> requires, boolean soyFile, String templateCode, String etag) {
     this.name = name;
     this.code = code;
+    this.etag = etag;
     if (provides != null) {
       this.provides = ImmutableList.copyOf(provides);
     } else {
@@ -84,12 +95,16 @@ public class DummyJsInput implements JsInput {
 
   @Override
   public boolean supportsEtags() {
-    return false;
+    return this.etag != null;
   }
 
   @Override
   public CodeWithEtag getCodeWithEtag() {
-    throw new UnsupportedOperationException();
+    if (this.etag == null) {
+      throw new UnsupportedOperationException();
+    }
+
+    return new CodeWithEtag(this.getCode(), this.etag);
   }
 
   @Override

--- a/test/org/plovr/InputFileHandlerTest.java
+++ b/test/org/plovr/InputFileHandlerTest.java
@@ -21,9 +21,9 @@ public class InputFileHandlerTest {
     String moduleUriBase = "http://plovr.org:9988/";
     String configId = "inputNameTest";
     Function<JsInput,String> converter = InputFileHandler.
-        createInputNameToUriConverter(moduleUriBase, configId);
+        createInputNameToUriConverter(moduleUriBase, configId, false);
 
-    JsInput input = createDummyJsInput("../../bar/foo.js");
+    JsInput input = createDummyJsInput("../../bar/foo.js", null);
     String uri = converter.apply(input);
     assertEquals(
         "../ should be replaced with $$/",
@@ -31,7 +31,22 @@ public class InputFileHandlerTest {
         uri);
   }
 
-  private static JsInput createDummyJsInput(String name) {
-    return new DummyJsInput(name, "alert('ok');", null, null);
+  @Test
+  public void testInputNameToUriConverterWithEtag() {
+    String moduleUriBase = "http://plovr.org:9988/";
+    String configId = "aggressiveCacheTest";
+    Function<JsInput,String> converter = InputFileHandler.
+        createInputNameToUriConverter(moduleUriBase, configId, true);
+
+    JsInput input = createDummyJsInput("bar/foo.js", "\"abcdef\"");
+    String uri = converter.apply(input);
+    assertEquals(
+        "_tag should be appended",
+        "http://plovr.org:9988/input/aggressiveCacheTest/bar/foo.js?_tag=abcdef",
+        uri);
+  }
+
+  private static JsInput createDummyJsInput(String name, String etag) {
+    return new DummyJsInput(name, "alert('ok');", etag);
   }
 }


### PR DESCRIPTION
We use the RAW mode for development, and in our codebase, Plovr adds so many script tags to our pages that even fetching them over localhost can take more than 10 seconds. 😒

This adds a new config option to set a long-lived Expires and max-age to files that can produce an ETag, and includes the tag as a cache-busting query parameter in the URI's served from /compile. Unchanged files are served directly from the browser's cache without consulting Plovr. ✨

This doesn't work on .soy files yet; I'd appreciate any thoughts you have on the subject. :)