### PR TITLE
Pass the parsed compiler options into the extract command

### DIFF
--- a/src/org/plovr/cli/ExtractCommand.java
+++ b/src/org/plovr/cli/ExtractCommand.java
@@ -76,7 +76,11 @@ public class ExtractCommand extends AbstractCommandRunner<ExtractCommandOptions>
 
     JsMessageExtractor extractor =
         new JsMessageExtractor(
-            new GoogleJsMessageIdGenerator(null), JsMessage.Style.CLOSURE);
+            new GoogleJsMessageIdGenerator(null),
+            JsMessage.Style.CLOSURE,
+            config.getCompilerOptions(null),
+            false
+        );
 
     Iterable<JsMessage> messages = extractor.extractMessages(
         Iterables.transform(inputs, new Function<JsInput, SourceFile>() {


### PR DESCRIPTION
This fixes a couple inconsistency issues, particularly https://github.com/bolinfest/plovr/issues/131.

I had to make the `compiler` argument to `Config.getCompilerOptions` nullable for this, since [the compiler used here is private to the extractor](https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/JsMessageExtractor.java#L125).

I think the ideal solution here would involve modifying that file in the compiler itself to allow an optional compiler instance to be passed in, but I'm not sure about the interop between the two repos so I'm sticking to modifying just plovr for now.