### PR TITLE
Don't generate URLs with a port of -1 when Host header is missing port

### DIFF
--- a/src/org/plovr/CompilationServer.java
+++ b/src/org/plovr/CompilationServer.java
@@ -217,6 +217,11 @@ public final class CompilationServer implements Runnable {
       host = referrer.getHost();
     }
 
+    // If the Host header doesn't include a port, getHost() gives us -1.                        
+    if (port == -1) {                                                                    
+      return String.format("%s://%s/", scheme, host);                                    
+    } 
+
     return String.format("%s://%s:%d/", scheme, host, port);
   }
 }

--- a/test/org/plovr/CompilationServerTest.java
+++ b/test/org/plovr/CompilationServerTest.java
@@ -25,6 +25,7 @@ public class CompilationServerTest {
                  server.getServerForExchange(createExchange("standard.dev:2345", "https://standard.local:4567")));
     assertEquals("http://standard.local:1234/",
                  server.getServerForExchange(createExchange(null, "http://standard.local:4567")));
+    assertEquals("http://standard.dev/", server.getServerForExchange(createExchange("standard.dev", null)));
   }
 
   private HttpExchange createExchange(String host, String referer) {


### PR DESCRIPTION
When running plovr on port 80 or 443, browsers do not send the port in the Host header when making requests to plovr. This causes plovr to generate URLs like https://standard.dev:-1/.

This patch modifies the compilation server to omit the port from generated URLs in that case.

We're using Plovr v6, so it would be great if this could make its way into a 6.0/6.1 dot release if you choose to land it.