### PR TITLE
Add "print-config" configuration option.

### DIFF
--- a/src/org/plovr/Config.java
+++ b/src/org/plovr/Config.java
@@ -119,6 +119,8 @@ public final class Config implements Comparable<Config> {
 
   private final boolean prettyPrint;
 
+  private final boolean printConfig;
+
   private final boolean printInputDelimiter;
 
   private final boolean enableAggressiveRawCaching;
@@ -228,6 +230,7 @@ public final class Config implements Comparable<Config> {
       WarningLevel warningLevel,
       boolean debug,
       boolean prettyPrint,
+      boolean printConfig,
       boolean printInputDelimiter,
       boolean enableAggressiveRawCaching,
       @Nullable File outputFile,
@@ -287,6 +290,7 @@ public final class Config implements Comparable<Config> {
     this.warningLevel = warningLevel;
     this.debug = debug;
     this.prettyPrint = prettyPrint;
+    this.printConfig = printConfig;
     this.printInputDelimiter = printInputDelimiter;
     this.enableAggressiveRawCaching = enableAggressiveRawCaching;
     this.outputFile = outputFile;
@@ -414,6 +418,7 @@ public final class Config implements Comparable<Config> {
         .put("level", getWarningLevel())
         .put("debug", debug)
         .put("pretty-print", prettyPrint)
+        .put("print-config", printConfig)
         .put("print-input-delimeter", printInputDelimiter)
         .put("soy-proto-file-descriptors", getSoyProtoFileDescriptors())
         .put("css-output-format", getCssOutputFormat())
@@ -710,6 +715,7 @@ public final class Config implements Comparable<Config> {
     options.setCodingConvention(new ClosureCodingConvention());
     warningLevel.setOptionsForWarningLevel(options);
     options.setPrettyPrint(prettyPrint);
+    options.setPrintConfig(printConfig);
     options.printInputDelimiter = printInputDelimiter;
     if (printInputDelimiter) {
       options.inputDelimiter = "// Input %num%: %name%";
@@ -1107,6 +1113,8 @@ public final class Config implements Comparable<Config> {
 
     private boolean prettyPrint = false;
 
+    private boolean printConfig = false;
+
     private boolean printInputDelimiter = false;
 
     private boolean enableAggressiveRawCaching = false;
@@ -1241,6 +1249,7 @@ public final class Config implements Comparable<Config> {
       this.warningLevel = config.warningLevel;
       this.debug = config.debug;
       this.prettyPrint = config.prettyPrint;
+      this.printConfig = config.printConfig;
       this.printInputDelimiter = config.printInputDelimiter;
       this.enableAggressiveRawCaching = config.enableAggressiveRawCaching;
       this.outputFile = config.outputFile;
@@ -1521,6 +1530,10 @@ public final class Config implements Comparable<Config> {
 
     public void setPrettyPrint(boolean prettyPrint) {
       this.prettyPrint = prettyPrint;
+    }
+
+    public void setPrintConfig(boolean newVal) {
+      this.printConfig = newVal;
     }
 
     public void setPrintInputDelimiter(boolean printInputDelimiter) {
@@ -1831,6 +1844,7 @@ public final class Config implements Comparable<Config> {
           warningLevel,
           debug,
           prettyPrint,
+          printConfig,
           printInputDelimiter,
           enableAggressiveRawCaching,
           outputFile,

--- a/src/org/plovr/ConfigOption.java
+++ b/src/org/plovr/ConfigOption.java
@@ -208,6 +208,20 @@ public enum ConfigOption {
     }
   }),
 
+  PRINT_CONFIG("print-config", new ConfigUpdater() {
+    @Override
+    public void apply(boolean value, Config.Builder builder) {
+      builder.setPrintConfig(value);
+    }
+
+    @Override
+    public boolean update(String printConfigParam, Config.Builder builder) {
+      boolean printConfig = Boolean.valueOf(printConfigParam);
+      builder.setPrintConfig(printConfig);
+      return true;
+    }
+  }),
+
   SOURCE_MAP_BASE_URL("source-map-base-url", new ConfigUpdater() {
     @Override
     public void apply(String sourceMapBaseUrl, Config.Builder builder) {


### PR DESCRIPTION
Hi @nicks,

This adds an option that corresponds to [Closure Compiler's `printConfig` option](https://github.com/google/closure-compiler/blob/d1a68e44d5de9462417e847a45408cdae5446a77/src/com/google/javascript/jscomp/CompilerOptions.java#L1196-L1199).
By enabling this, Closure Compiler will dump its configuration options on stderr, which may be useful for checking what changes each configuration option of plovr actually result in.