### PR TITLE
Fix update-repository.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ To upgrade one of Closure Library, go to the official repo and find the SHA dige
 of the commit you want to sync to. Then run.
 
 ```
-scripts/update-repository.sh closure-library sha-digest
+scripts/update-closure-library.sh sha-digest
 ```
 
 Sometimes this doesn't work because `git subtree` is buggy. If nothing updates, try running:
 
 ```
-scripts/update-repository.sh closure-library master
+scripts/update-closure-library.sh master
 git reset --hard origin/master
-scripts/update-repository.sh closure-library sha-digest
+scripts/update-closure-library.sh sha-digest
 ```
 
 This will bully `git subtree` into shape.

--- a/scripts/update-closure-library.sh
+++ b/scripts/update-closure-library.sh
@@ -20,5 +20,5 @@ set -ex
 git subtree pull --prefix="closure/${REPOSITORY}" "git@github.com:google/${REPOSITORY}" "$COMMIT"
 echo "$COMMIT" > tools/imports/rev-$REPOSITORY.txt
 
-./listfiles.sh closure/closure-library/closure/goog > library_manifest.txt
-./listfiles.sh closure/closure-library/third_party/closure/goog > third_party_manifest.txt
+./listfiles.sh closure/closure-library/closure/goog | sort > library_manifest.txt
+./listfiles.sh closure/closure-library/third_party/closure/goog | sort > third_party_manifest.txt

--- a/scripts/update-closure-library.sh
+++ b/scripts/update-closure-library.sh
@@ -2,7 +2,7 @@
 #
 # Use this script to update closure-library. Usage:
 #
-# ./update-repository.sh hash
+# ./update-closure-library.sh hash
 
 cd `dirname $0`/..
 
@@ -14,11 +14,11 @@ if [ $# -ne $EXPECTED_ARGS ]; then
 fi
 
 REPOSITORY="closure-library"
-COMMIT=$2
+COMMIT=$1
 
 set -ex
-git subtree pull --prefix="closure/${REPOSITORY}" "git@github.com:google/${REPOSITORY}" "$2"
-echo "$2" > tools/imports/rev-$1.txt
+git subtree pull --prefix="closure/${REPOSITORY}" "git@github.com:google/${REPOSITORY}" "$COMMIT"
+echo "$COMMIT" > tools/imports/rev-$REPOSITORY.txt
 
 ./listfiles.sh closure/closure-library/closure/goog > library_manifest.txt
 ./listfiles.sh closure/closure-library/third_party/closure/goog > third_party_manifest.txt


### PR DESCRIPTION
`update-repository.sh` doesn't work now.

This fixes
- `update-repository.sh hash` throws an error (9bb808c157274f54a33e53e06edccb0739f79a02 broke it)
- generated manifest files are not sorted

Also renames to `update-closure-library.sh` and updates README.